### PR TITLE
Fix typo in alt text for Twitter icon (Fixes #17)

### DIFF
--- a/template.php
+++ b/template.php
@@ -743,7 +743,7 @@ function borg_menu_tree__user_menu($variables) {
   $output .= '  </ul>';
 
   $output .= '  <a class="icon" title="Find us on GitHub" href="https://github.com/backdrop/backdrop"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>';
-  $output .= '  <a class="icon" title="Follow os on Twitter" href="https://twitter.com/backdropcms"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>';
+  $output .= '  <a class="icon" title="Follow us on Twitter" href="https://twitter.com/backdropcms"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>';
   $output .= '  <a class="icon" title="Subscribe to our Newsletter" href="https://backdropcms.org/newsletter"><i class="fa fa-envelope fa-2x" aria-hidden="true"></i></a>';
 
   $output .= '</nav>';


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/borg/issues/17